### PR TITLE
Remove AWS keys only when they are not defined

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,10 @@ wal_e_user: 'postgres'
 wal_e_group: 'postgres'
 wal_e_pgdata_dir: '/var/lib/postgresql/9.1/main/'
 
+# Even though S3 doesn't belong to any regions, we still
+# need to provide either this or WALE_S3_ENDPOINT to wal-e command
+wal_e_aws_region: 'us-east-1'
+
 wal_e_s3_prefix: 's3://some-bucket/directory/or/whatever'
 
 # Set it to true to enable IAM instance profiles.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,11 +27,11 @@
     mode=0600
   when: wal_e_aws_access_key is defined
 
-- name: setup AWS credentials AWS_ACCESS_KEY_ID
+- name: clean AWS credentials AWS_ACCESS_KEY_ID
   file: |
     state=absent
     path="{{ wal_e_envdir }}/AWS_ACCESS_KEY_ID"
-  when: wal_e_aws_access_key is defined
+  when: wal_e_aws_access_key is not defined
 
 - name: setup AWS credentials AWS_SECRET_ACCESS_KEY
   copy: |
@@ -42,11 +42,12 @@
     mode=0600
   when: wal_e_aws_secret_key is defined
 
-- name: setup AWS credentials AWS_SECRET_ACCESS_KEY
+- name: clean AWS credentials AWS_SECRET_ACCESS_KEY
   file: |
     state=absent
     path="{{ wal_e_envdir }}/AWS_SECRET_ACCESS_KEY"
-  when: wal_e_aws_secret_key is defined
+  when: wal_e_aws_secret_key is not defined
+
 
 - name: setup WAL-E S3 endpoint
   copy: |
@@ -57,7 +58,7 @@
     mode=0600
   when: wal_e_s3_endpoint is defined
 
-- name: setup WAL-E S3 endpoint
+- name: clean WAL-E S3 endpoint
   file: |
     state=absent
     path="{{ wal_e_envdir }}/WALE_S3_ENDPOINT"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,20 @@
     path="{{ wal_e_envdir }}/AWS_SECRET_ACCESS_KEY"
   when: wal_e_aws_secret_key is not defined
 
+- name: setup AWS credentials AWS_REGION
+  copy: |
+    content="{{ wal_e_aws_region }}"
+    dest="{{ wal_e_envdir }}/AWS_REGION"
+    owner="{{ wal_e_user}}"
+    group="{{ wal_e_group }}"
+    mode=0600
+  when: wal_e_aws_region is defined
+
+- name: clean AWS credentials AWS_REGION
+  file: |
+    state=absent
+    path="{{ wal_e_envdir }}/AWS_REGION"
+  when: wal_e_aws_region is not defined
 
 - name: setup WAL-E S3 endpoint
   copy: |


### PR DESCRIPTION
Right now it happens when they are defined, which makes little sense.

Also added support for AWS_REGION variable, which I needed